### PR TITLE
Add workspace extends to react sample tsconfig

### DIFF
--- a/apps/react-sample/tsconfig.json
+++ b/apps/react-sample/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "target": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "types": ["vite/client", "node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add a tsconfig for the react sample that extends the workspace configuration
- carry forward sample-specific compiler options so aliases resolve correctly

## Testing
- pnpm --filter react-sample type:check

------
https://chatgpt.com/codex/tasks/task_b_68cecddaefdc83208523037e1e6374d0